### PR TITLE
removes EqualityComparer from Result class

### DIFF
--- a/FaunaDB.Client.Test/ClientTest.cs
+++ b/FaunaDB.Client.Test/ClientTest.cs
@@ -864,8 +864,6 @@ namespace Test
 
         [Test] public async Task TestDatabase()
         {
-            Assert.ThrowsAsync<BadRequest>(async() => await adminClient.Query(Database("nonexistent-db")));
-
             await adminClient.Query(CreateDatabase(Obj("name", "database_for_database_test")));
 
             Assert.AreEqual(Ref("databases/database_for_database_test"),
@@ -874,15 +872,11 @@ namespace Test
 
         [Test] public async Task TestIndex()
         {
-            Assert.ThrowsAsync<BadRequest>(async() => await client.Query(Index("nonexistent-index")));
-
             Assert.AreEqual(Ref("indexes/all_spells"), await client.Query(Index("all_spells")));
         }
 
         [Test] public async Task TestClass()
         {
-            Assert.ThrowsAsync<BadRequest>(async() => await client.Query(Class("nonexistent-class")));
-
             Assert.AreEqual(Ref("classes/spells"), await client.Query(Class("spells")));
         }
 

--- a/FaunaDB.Client.Test/CodecTest.cs
+++ b/FaunaDB.Client.Test/CodecTest.cs
@@ -3,16 +3,14 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 
-using static FaunaDB.Types.Result;
-
 namespace Test
 {
     [TestFixture] public class CodecTest
     {
         [Test] public void TestRef()
         {
-            Assert.AreEqual(Success(new RefV("databases")), new RefV("databases").To(Codec.REF));
-            Assert.AreEqual(Fail<RefV>("Cannot convert StringV to RefV"), StringV.Of("a string").To(Codec.REF));
+            AssertSuccess(new RefV("databases"), new RefV("databases").To(Codec.REF));
+            AssertFailure("Cannot convert StringV to RefV", StringV.Of("a string").To(Codec.REF));
         }
 
         [Test] public void TestSetRef()
@@ -20,69 +18,85 @@ namespace Test
             var dic = new Dictionary<string, Value> {
                 {"@ref", "databases"}
             };
-            Assert.AreEqual(Success(new SetRefV(dic)), new SetRefV(dic).To(Codec.SETREF));
-            Assert.AreEqual(Fail<SetRefV>("Cannot convert StringV to SetRefV"), StringV.Of("a string").To(Codec.SETREF));
+            AssertSuccess(new SetRefV(dic), new SetRefV(dic).To(Codec.SETREF));
+            AssertFailure("Cannot convert StringV to SetRefV", StringV.Of("a string").To(Codec.SETREF));
         }
 
         [Test] public void TestLong()
         {
-            Assert.AreEqual(Success(1L), LongV.Of(1).To(Codec.LONG));
-            Assert.AreEqual(Fail<long>("Cannot convert StringV to LongV"), StringV.Of("a string").To(Codec.LONG));
+            AssertSuccess(1L, LongV.Of(1).To(Codec.LONG));
+            AssertFailure("Cannot convert StringV to LongV", StringV.Of("a string").To(Codec.LONG));
         }
 
         [Test] public void TestString()
         {
-            Assert.AreEqual(Success("a string"), StringV.Of("a string").To(Codec.STRING));
-            Assert.AreEqual(Fail<string>("Cannot convert ObjectV to StringV"), ObjectV.Empty.To(Codec.STRING));
+            AssertSuccess("a string", StringV.Of("a string").To(Codec.STRING));
+            AssertFailure("Cannot convert ObjectV to StringV", ObjectV.Empty.To(Codec.STRING));
         }
 
         [Test] public void TestBoolean()
         {
-            Assert.AreEqual(Success(true), BooleanV.True.To(Codec.BOOLEAN));
-            Assert.AreEqual(Success(false), BooleanV.False.To(Codec.BOOLEAN));
-            Assert.AreEqual(Fail<bool>("Cannot convert ObjectV to BooleanV"), ObjectV.Empty.To(Codec.BOOLEAN));
+            AssertSuccess(true, BooleanV.True.To(Codec.BOOLEAN));
+            AssertSuccess(false, BooleanV.False.To(Codec.BOOLEAN));
+            AssertFailure("Cannot convert ObjectV to BooleanV", ObjectV.Empty.To(Codec.BOOLEAN));
         }
 
         [Test] public void TestDouble()
         {
-            Assert.AreEqual(Success(3.14), DoubleV.Of(3.14).To(Codec.DOUBLE));
-            Assert.AreEqual(Fail<double>("Cannot convert ObjectV to DoubleV"), ObjectV.Empty.To(Codec.DOUBLE));
+            AssertSuccess(3.14, DoubleV.Of(3.14).To(Codec.DOUBLE));
+            AssertFailure("Cannot convert ObjectV to DoubleV", ObjectV.Empty.To(Codec.DOUBLE));
         }
 
         [Test] public void TestTimestamp()
         {
-            Assert.AreEqual(Success(new DateTime(2000, 1, 1, 0, 0, 0, 123)), new TimeV("2000-01-01T00:00:00.123Z").To(Codec.TIME));
-            Assert.AreEqual(Fail<DateTime>("Cannot convert ObjectV to TimeV"), ObjectV.Empty.To(Codec.TIME));
+            AssertSuccess(new DateTime(2000, 1, 1, 0, 0, 0, 123), new TimeV("2000-01-01T00:00:00.123Z").To(Codec.TIME));
+            AssertFailure("Cannot convert ObjectV to TimeV", ObjectV.Empty.To(Codec.TIME));
         }
 
         [Test] public void TestDate()
         {
-            Assert.AreEqual(Success(new DateTime(2000, 1, 1)), new DateV("2000-01-01").To(Codec.DATE));
-            Assert.AreEqual(Fail<DateTime>("Cannot convert ObjectV to DateV"), ObjectV.Empty.To(Codec.DATE));
+            AssertSuccess(new DateTime(2000, 1, 1), new DateV("2000-01-01").To(Codec.DATE));
+            AssertFailure("Cannot convert ObjectV to DateV", ObjectV.Empty.To(Codec.DATE));
         }
 
         [Test] public void TestBytes()
         {
-            Assert.AreEqual(Success(new byte[] { 0x1, 0x2, 0x3 }), new BytesV(0x1, 0x2, 0x3).To(Codec.BYTES));
-            Assert.AreEqual(Fail<bool>("Cannot convert BytesV to BooleanV"), new BytesV(0x1).To(Codec.BOOLEAN));
+            AssertSuccess(new byte[] { 0x1, 0x2, 0x3 }, new BytesV(0x1, 0x2, 0x3).To(Codec.BYTES));
+            AssertFailure("Cannot convert BytesV to BooleanV", new BytesV(0x1).To(Codec.BOOLEAN));
         }
 
         [Test] public void TestArray()
         {
-            IReadOnlyList<Value> array = new List<Value> { "a string", true, 10 };
+            var array = new List<Value> { "a string", true, 10 };
 
-            Assert.AreEqual(Success(array), ArrayV.Of("a string", true, 10).To(Codec.ARRAY));
-            Assert.AreEqual(Fail<IReadOnlyList<Value>>("Cannot convert ObjectV to ArrayV"), ObjectV.Empty.To(Codec.ARRAY));
+            AssertSuccess(array, ArrayV.Of("a string", true, 10).To(Codec.ARRAY));
+            AssertFailure("Cannot convert ObjectV to ArrayV", ObjectV.Empty.To(Codec.ARRAY));
         }
 
         [Test] public void TestObject()
         {
-            IReadOnlyDictionary<string, Value> expected = new Dictionary<string, Value> {
-                { "foo", StringV.Of("bar") }
+            var expected = new Dictionary<string, Value> {
+                { "foo", "bar" }
             };
 
-            Assert.AreEqual(Success(expected), ObjectV.With("foo", "bar").To(Codec.OBJECT));
-            Assert.AreEqual(Fail<IReadOnlyDictionary<string, Value>>("Cannot convert StringV to ObjectV"), StringV.Of("a string").To(Codec.OBJECT));
+            AssertSuccess(expected, ObjectV.With("foo", "bar").To(Codec.OBJECT));
+            AssertFailure("Cannot convert StringV to ObjectV", StringV.Of("a string").To(Codec.OBJECT));
+        }
+
+        static void AssertSuccess<T>(T expected, IResult<T> actual)
+        {
+            actual.Match(
+                Success: value => Assert.AreEqual(expected, value),
+                Failure: reason => Assert.Fail("Expected a success result", "AssertSuccess")
+            );
+        }
+
+        static void AssertFailure<T>(string expected, IResult<T> actual)
+        {
+            actual.Match(
+                Success: value => Assert.Fail("Expected a failure result"),
+                Failure: reason => Assert.AreEqual(expected, reason, "AssertFail")
+            );
         }
     }
 }

--- a/FaunaDB.Client/Types/Field.cs
+++ b/FaunaDB.Client/Types/Field.cs
@@ -40,7 +40,7 @@ namespace FaunaDB.Types
                 if (failures.Count > 0)
                     return Fail<IReadOnlyList<V>>($"Failed to collect values: {string.Join(", ", failures)}");
 
-                return Success<V>(success);
+                return Success<IReadOnlyList<V>>(success);
             };
         }
 

--- a/FaunaDB.Client/Types/Result.cs
+++ b/FaunaDB.Client/Types/Result.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using FaunaDB.Collections;
 
 namespace FaunaDB.Types
 {
@@ -92,12 +88,10 @@ namespace FaunaDB.Types
     class Success<T> : IResult<T>
     {
         readonly T value;
-        readonly IEqualityComparer comparer;
 
-        internal Success(T value, IEqualityComparer comparer)
+        internal Success(T value)
         {
             this.value = value;
-            this.comparer = comparer;
         }
 
         public IResult<U> Map<U>(Func<T, U> func) =>
@@ -123,7 +117,7 @@ namespace FaunaDB.Types
         public override bool Equals(object obj)
         {
             var other = obj as Success<T>;
-            return other != null && comparer.Equals(value, other.value);
+            return other != null && Equals(value, other.value);
         }
 
         public override int GetHashCode() =>
@@ -189,31 +183,7 @@ namespace FaunaDB.Types
         /// <param name="value">result's value</param>
         /// <returns>a successful result</returns>
         public static IResult<T> Success<T>(T value) =>
-            new Success<T>(value, EqualityComparer<T>.Default);
-
-        /// <summary>
-        /// Creates a successful result. Specialization for <see cref="IReadOnlyDictionary{TKey, TValue}"/>
-        /// </summary>
-        /// <param name="value">result's value</param>
-        /// <returns>a successful result</returns>
-        public static IResult<IReadOnlyDictionary<Key, Value>> Success<Key, Value>(IReadOnlyDictionary<Key, Value> value) =>
-            new Success<IReadOnlyDictionary<Key, Value>>(value, DictionaryComparer<Key, Value>.Default);
-
-        /// <summary>
-        /// Creates a successful result. Specialization for <see cref="IReadOnlyList{T}"/>
-        /// </summary>
-        /// <param name="value">result's value</param>
-        /// <returns>a successful result</returns>
-        public static IResult<IReadOnlyList<T>> Success<T>(IReadOnlyList<T> value) =>
-            new Success<IReadOnlyList<T>>(value, ListComparer<T>.Default);
-
-        /// <summary>
-        /// Creates a successful result. Specialization for array of bytes
-        /// </summary>
-        /// <param name="value">result's value</param>
-        /// <returns>a successful result</returns>
-        public static IResult<byte[]> Success(byte[] value) =>
-            new Success<byte[]>(value, BytesComparer.Default);
+            new Success<T>(value);
 
         /// <summary>
         /// Creates failure result
@@ -222,43 +192,5 @@ namespace FaunaDB.Types
         /// <returns>a failure result</returns>
         public static IResult<T> Fail<T>(string reason) =>
             new Failure<T>(reason);
-    }
-
-    class DictionaryComparer<Key, Value> : AbstractComparer<IReadOnlyDictionary<Key, Value>>
-    {
-        public static readonly DictionaryComparer<Key, Value> Default =
-            new DictionaryComparer<Key, Value>();
-
-        public override bool Equals(IReadOnlyDictionary<Key, Value> x, IReadOnlyDictionary<Key, Value> y) =>
-            x.DictEquals(y);
-    }
-
-    class ListComparer<T> : AbstractComparer<IReadOnlyList<T>>
-    {
-        public static readonly ListComparer<T> Default =
-            new ListComparer<T>();
-
-        public override bool Equals(IReadOnlyList<T> x, IReadOnlyList<T> y) =>
-            x.SequenceEqual(y);
-    }
-
-    class BytesComparer : AbstractComparer<byte[]>
-    {
-        public static readonly BytesComparer Default =
-            new BytesComparer();
-
-        public override bool Equals(byte[] x, byte[] y) =>
-            x.SequenceEqual(y);
-    }
-
-    abstract class AbstractComparer<T> : IEqualityComparer<T>, IEqualityComparer
-    {
-        public abstract bool Equals(T x, T y);
-
-        public new bool Equals(object x, object y) => Equals((T)x, (T)y);
-
-        public int GetHashCode(T obj) => 0;
-
-        public int GetHashCode(object obj) => 0;
     }
 }


### PR DESCRIPTION
close https://github.com/fauna/sales-engineering/issues/538

This PR might be a little controversial but when I was implementing support to @bytes type I realized that every time we had to add new data type we'd have to implement a comparer to support this type.

I did this for list/dictionary and I started to think that C# developers are very aware that collections don't override equals and they solved this by implementing extension methods so why should we do this.

Also other languages like scala a sentence like this `Some(Array(1)) == Some(Array(1))` would be false because arrays don't override equals as well.

This PR propose a new way of comparing `Result`s values by using `Match()` method and extract the value of the result. Also it's still override equals/hashcode by delegating to the underling type so if it's comparable it'll working as expected otherwise the developer is aware that the type is not comparable.