### PR TITLE
pinning FaunaDB API version to 2.0

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+1.0.1-SNAPSHOT
+* Pinning FaunaDB API version to 2.0
+
 1.0.0
 * Official release
 

--- a/FaunaDB.Client/Client/DefaultClientIO.cs
+++ b/FaunaDB.Client/Client/DefaultClientIO.cs
@@ -33,6 +33,7 @@ namespace FaunaDB.Client
             client.Timeout = timeout;
             client.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            client.DefaultRequestHeaders.Add("X-FaunaDB-API-Version", "2.0");
 
             authHeader = AuthString(secret);
         }


### PR DESCRIPTION
the branch `faunadb-csharp-1.0` was created so we can now merge all stuff related to old driver on it