### PR TITLE
Make values construction more consistent

### DIFF
--- a/FaunaDB.Client/Types/BytesV.cs
+++ b/FaunaDB.Client/Types/BytesV.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Text;
 using FaunaDB.Query;
 using Newtonsoft.Json;
 
@@ -14,11 +13,23 @@ namespace FaunaDB.Types
     /// </summary>
     public class BytesV : ScalarValue<byte[]>
     {
-        internal BytesV(string base64) : base(FromUrlSafeBase64(base64))
+        /// <summary>
+        /// Creates a new instance of <see cref="BytesV"/> from a base64 string.
+        /// </summary>
+        public BytesV(string base64) : base(FromUrlSafeBase64(base64))
         { }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="BytesV"/> from a variable lenght of bytes.
+        /// </summary>
         public BytesV(params byte[] value) : base(value)
         { }
+
+        public static BytesV Of(string base64) =>
+            new BytesV(base64);
+
+        public static BytesV Of(params byte[] value) =>
+            new BytesV(value);
 
         public override bool Equals(Expr v)
         {

--- a/FaunaDB.Client/Types/ScalarValue.cs
+++ b/FaunaDB.Client/Types/ScalarValue.cs
@@ -101,12 +101,14 @@ namespace FaunaDB.Types
         /// <summary>
         /// Create a Ref from a string, such as <c>new Ref("databases/prydain")</c>.
         /// </summary>
-        /// <param name="value">Value.</param>
         public RefV(string value) : base(value)
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
         }
+
+        public RefV Of(string value) =>
+            new RefV(value);
 
         protected internal override void WriteJson(JsonWriter writer)
         {
@@ -123,11 +125,14 @@ namespace FaunaDB.Types
     /// </summary>
     public sealed class SetRefV : ScalarValue<IReadOnlyDictionary<string, Value>>
     {
-        public SetRefV(IReadOnlyDictionary<string, Value> name) : base(name)
+        public SetRefV(IReadOnlyDictionary<string, Value> value) : base(value)
         {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
         }
+
+        public SetRefV Of(IReadOnlyDictionary<string, Value> value) =>
+            new SetRefV(value);
 
         protected internal override void WriteJson(JsonWriter writer)
         {
@@ -156,12 +161,21 @@ namespace FaunaDB.Types
     public sealed class TimeV : ScalarValue<DateTime>
     {
         /// <summary>
-        /// Construct from an iso8601 time string.
+        /// Construct a TimeV from an iso8601 time string.
         /// It must use the 'Z' time zone.
         /// </summary>
         public TimeV(string iso8601Time) : base(DateTimeUtil.FromIsoTime(iso8601Time, TimeFormat)) { }
 
+        /// <summary>
+        /// Construct a TimeV from a <see cref="DateTime"/> object.
+        /// </summary>
         public TimeV(DateTime dateTime) : base(dateTime) { }
+
+        public static TimeV Of(string isoTime) =>
+            new TimeV(isoTime);
+
+        public static TimeV Of(DateTime dateTime) =>
+            new TimeV(dateTime);
 
         /// <summary>
         /// Convert from a DateTime by rendering as iso8601.
@@ -207,11 +221,20 @@ namespace FaunaDB.Types
     public sealed class DateV : ScalarValue<DateTime>
     {
         /// <summary>
-        /// Construct from an iso8601 date string.
+        /// Construct a DateV from an iso8601 date string.
         /// </summary>
         public DateV(string iso8601Date) : base(DateTimeUtil.FromIsoDate(iso8601Date, DateFormat)) { }
 
+        /// <summary>
+        /// Construct a DateV from a <see cref="DateTime"/> object.
+        /// </summary>
         public DateV(DateTime dateDate) : base(dateDate) { }
+
+        public static DateV Of(string isoDate) =>
+            new DateV(isoDate);
+
+        public static DateV Of(DateTime dateTime) =>
+            new DateV(dateTime);
 
         /// <summary>
         /// Convert from a DateTime by rendering as iso8601.


### PR DESCRIPTION
This is just to make the api more consistent. I've been noticing that in some classes we provide constructors and other we provide factory methods. In this PR I create some factory methods for missing classes. I didn't touch the classes that has implicit conversions like string, double, long and etc.