### PR TITLE
Fix decoder cast among Values type

### DIFF
--- a/FaunaDB.Client.Test/DecoderTest.cs
+++ b/FaunaDB.Client.Test/DecoderTest.cs
@@ -374,6 +374,25 @@ namespace Test
         }
 
         [Test]
+        public void TestCastErrors()
+        {
+            Assert.AreEqual(
+                "Cannot cast FaunaDB.Types.StringV to FaunaDB.Types.ObjectV",
+                Assert.Throws<InvalidOperationException>(() => Decode<ObjectV>("a string")).Message
+            );
+
+            Assert.AreEqual(
+                "Cannot cast FaunaDB.Types.StringV to FaunaDB.Types.LongV",
+                Assert.Throws<InvalidOperationException>(() => Decode<LongV>("a string")).Message
+            );
+
+            Assert.AreEqual(
+                "Cannot cast FaunaDB.Types.ObjectV to FaunaDB.Types.RefV",
+                Assert.Throws<InvalidOperationException>(() => Decode<RefV>(ObjectV.Empty)).Message
+            );
+        }
+
+        [Test]
         public void TestErrors()
         {
             Assert.AreEqual(

--- a/FaunaDB.Client/Types/Decoder.cs
+++ b/FaunaDB.Client/Types/Decoder.cs
@@ -76,8 +76,13 @@ namespace FaunaDB.Types
 
         static object DecodeIntern(Value value, Type dstType)
         {
-            if (typeof(object) != dstType && dstType.IsAssignableFrom(value.GetType()))
-                return value;
+            if (typeof(Value).IsAssignableFrom(dstType))
+            {
+                if (dstType.IsAssignableFrom(value.GetType()))
+                    return value;
+
+                throw new InvalidOperationException($"Cannot cast {value.GetType()} to {dstType}");
+            }
 
             switch (Type.GetTypeCode(dstType))
             {


### PR DESCRIPTION
This fix the case when we want to decode a `StringV` to a `Value` for example, since `StringV` extends `Value` we could just assign the string, but instead it was trying to instantiate a `Value`.