### PR TITLE
Some general improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Don't throw exception for missing attributes when constructing objects, assign default value
 - Fix default missing constructor for value types
 - Encode/Decode enums as strings
+- Adds support for `DateTimeOffset` class
+- `QueryV` receives a dictionary not an `Expr`
 
 ## 1.0.0
 

--- a/FaunaDB.Client.Test/DecoderTest.cs
+++ b/FaunaDB.Client.Test/DecoderTest.cs
@@ -36,6 +36,9 @@ namespace Test
             Assert.AreEqual(new DateTime(2001, 1, 1), Decode<DateTime>(new DateV("2001-01-01")));
             Assert.AreEqual(new DateTime(2000, 1, 1, 1, 10, 30, 123), Decode<DateTime>(new TimeV("2000-01-01T01:10:30.123Z")));
 
+            Assert.AreEqual(new DateTimeOffset(2001, 1, 1, 0, 0, 0, TimeSpan.Zero), Decode<DateTimeOffset>(new DateV("2001-01-01")));
+            Assert.AreEqual(new DateTimeOffset(2000, 1, 1, 1, 10, 30, 123, TimeSpan.Zero), Decode<DateTimeOffset>(new TimeV("2000-01-01T01:10:30.123Z")));
+
             Assert.AreEqual(new byte[] { 1, 2, 3 }, Decode<byte[]>(new BytesV(1, 2, 3)));
         }
 
@@ -169,21 +172,30 @@ namespace Test
         {
             public string Description { get; set; }
             public double Price { get; set; }
+            public DateTime Created { get; set; }
+            public DateTimeOffset LastUpdated { get; set; }
 
             [FaunaConstructor]
-            public Product([FaunaField("Description")] string description, [FaunaField("Price")] double price)
+            public Product([FaunaField("Description")] string description,
+                           [FaunaField("Price")] double price,
+                           [FaunaField("Created")] DateTime created,
+                           [FaunaField("LastUpdated")] DateTimeOffset lastUpdated)
             {
                 Description = description;
                 Price = price;
+                Created = created;
+                LastUpdated = lastUpdated;
             }
         }
 
         [Test]
         public void TestUserClassConstructor()
         {
-            var person = Decode<Product>(ObjectV.With("Description", "Laptop", "Price", 999.9));
+            var person = Decode<Product>(ObjectV.With("Description", "Laptop", "Price", 999.9, "Created", DateV.Of("2000-01-01"), "LastUpdated", TimeV.Of("2001-01-02T11:00:00.123Z")));
             Assert.AreEqual("Laptop", person.Description);
             Assert.AreEqual(999.9, person.Price);
+            Assert.AreEqual(new DateTime(2000, 1, 1), person.Created);
+            Assert.AreEqual(new DateTimeOffset(2001, 1, 2, 11, 0, 0, 123, TimeSpan.Zero), person.LastUpdated);
         }
 
         class Order

--- a/FaunaDB.Client.Test/DeserializationTest.cs
+++ b/FaunaDB.Client.Test/DeserializationTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using FaunaDB.Query;
 using FaunaDB.Types;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -217,8 +218,10 @@ namespace Test
         [Test]
         public void TestQuery()
         {
-            AssertJsonEqual(QueryV.Of("x", Add(Var("x"), 1)), "{\"@query\":{\"lambda\":\"x\",\"expr\":{\"add\":[{\"var\":\"x\"},1]}}}");
-            AssertJsonEqual(QueryV.Of(x => Add(x, 1)), "{\"@query\":{\"lambda\":\"x\",\"expr\":{\"add\":[{\"var\":\"x\"},1]}}}");
+            AssertJsonEqual(
+                new QueryV(new Dictionary<string, Expr> { { "lambda", "x" }, { "expr", Add(Var("x"), 1) } }),
+                "{\"@query\":{\"lambda\":\"x\",\"expr\":{\"add\":[{\"var\":\"x\"},1]}}}"
+            );
         }
     }
 }

--- a/FaunaDB.Client.Test/EncoderTest.cs
+++ b/FaunaDB.Client.Test/EncoderTest.cs
@@ -25,6 +25,9 @@ namespace Test
             Assert.AreEqual(new DateV("2001-01-01"), Encode(new DateTime(2001, 1, 1)));
             Assert.AreEqual(new TimeV("2000-01-01T01:10:30.123Z"), Encode(new DateTime(2000, 1, 1, 1, 10, 30, 123)));
 
+            Assert.AreEqual(new DateV("2001-01-01"), Encode(new DateTimeOffset(2001, 1, 1, 0, 0, 0, TimeSpan.Zero)));
+            Assert.AreEqual(new TimeV("2000-01-01T01:10:30.123Z"), Encode(new DateTimeOffset(2000, 1, 1, 1, 10, 30, 123, TimeSpan.Zero)));
+
             //float point
             Assert.AreEqual(DoubleV.Of((float)3.14), Encode((float)3.14));
             Assert.AreEqual(DoubleV.Of(3.14), Encode((double)3.14));
@@ -142,6 +145,9 @@ namespace Test
             [FaunaField("birth_date")]
             public DateTime BirthDate { get; }
 
+            [FaunaField("birth_date2")]
+            public DateTimeOffset BirthDate2 { get; }
+
             [FaunaField("address")]
             public Address Address { get; }
 
@@ -152,6 +158,7 @@ namespace Test
             {
                 Name = name;
                 BirthDate = birthDate;
+                BirthDate2 = new DateTimeOffset(birthDate, new TimeSpan(-1, 0, 0));
                 Address = address;
                 Avatar = avatar;
             }
@@ -161,7 +168,7 @@ namespace Test
         public void TestUserClass()
         {
             Assert.AreEqual(
-                ObjectV.With("name", "John", "birth_date", new DateV("1980-01-01"), "address", ObjectV.With("number", 123, "street", "Market St"), "avatar_image", new BytesV(1, 2, 3, 4)),
+                ObjectV.With("name", "John", "birth_date", new DateV("1980-01-01"), "birth_date2", new TimeV("1980-01-01T01:00:00.0Z"), "address", ObjectV.With("number", 123, "street", "Market St"), "avatar_image", new BytesV(1, 2, 3, 4)),
                 Encode(new Person("John", new DateTime(1980, 1, 1), new Address("Market St", 123), Person.DefaultAvatar))
             );
 
@@ -169,8 +176,8 @@ namespace Test
 
             Assert.AreEqual(
                 ArrayV.Of(
-                    ObjectV.With("name", "John", "birth_date", new DateV("1980-01-01"), "address", ObjectV.With("number", 123, "street", "Market St"), "avatar_image", new BytesV(1, 2, 3, 4)),
-                    ObjectV.With("name", "Mary", "birth_date", new DateV("1975-01-01"), "address", ObjectV.With("number", 321, "street", "Mission St"), "avatar_image", new BytesV(1, 2, 3, 4))
+                    ObjectV.With("name", "John", "birth_date", new DateV("1980-01-01"), "birth_date2", new TimeV("1980-01-01T01:00:00.0Z"), "address", ObjectV.With("number", 123, "street", "Market St"), "avatar_image", new BytesV(1, 2, 3, 4)),
+                    ObjectV.With("name", "Mary", "birth_date", new DateV("1975-01-01"), "birth_date2", new TimeV("1975-01-01T01:00:00.0Z"), "address", ObjectV.With("number", 321, "street", "Mission St"), "avatar_image", new BytesV(1, 2, 3, 4))
                 ),
                 Encode(new List<Person> {
                     new Person("John", new DateTime(1980, 1, 1), new Address("Market St", 123), Person.DefaultAvatar),
@@ -182,8 +189,8 @@ namespace Test
 
             Assert.AreEqual(
                 ObjectV.With(
-                    "first", ObjectV.With("name", "John", "birth_date", new DateV("1980-01-01"), "address", ObjectV.With("number", 123, "street", "Market St"), "avatar_image", new BytesV(1, 2, 3, 4)),
-                    "second", ObjectV.With("name", "Mary", "birth_date", new DateV("1975-01-01"), "address", ObjectV.With("number", 321, "street", "Mission St"), "avatar_image", new BytesV(1, 2, 3, 4))
+                    "first", ObjectV.With("name", "John", "birth_date", new DateV("1980-01-01"), "birth_date2", new TimeV("1980-01-01T01:00:00.0Z"), "address", ObjectV.With("number", 123, "street", "Market St"), "avatar_image", new BytesV(1, 2, 3, 4)),
+                    "second", ObjectV.With("name", "Mary", "birth_date", new DateV("1975-01-01"), "birth_date2", new TimeV("1975-01-01T01:00:00.0Z"), "address", ObjectV.With("number", 321, "street", "Mission St"), "avatar_image", new BytesV(1, 2, 3, 4))
                 ),
                 Encode(new Dictionary<string, Person> {
                     {"first", new Person("John", new DateTime(1980, 1, 1), new Address("Market St", 123), Person.DefaultAvatar)},

--- a/FaunaDB.Client.Test/ErrorsTest.cs
+++ b/FaunaDB.Client.Test/ErrorsTest.cs
@@ -145,7 +145,7 @@ namespace Test
         public override bool Equals(Expr v) => false;
         protected override int HashCode() => 0;
 
-        protected override void WriteJson(JsonWriter writer)
+        protected internal override void WriteJson(JsonWriter writer)
         {
             writer.WriteStartObject();
             writer.WritePropertyName("foo");

--- a/FaunaDB.Client.Test/OperatorTest.cs
+++ b/FaunaDB.Client.Test/OperatorTest.cs
@@ -1,4 +1,5 @@
-﻿using FaunaDB.Query;
+﻿using System;
+using FaunaDB.Query;
 using FaunaDB.Types;
 using NUnit.Framework;
 
@@ -8,7 +9,7 @@ namespace Test
 {
     [TestFixture] public class OperatorTest
     {
-        [Test] public void TestImplicit()
+        [Test] public void TestImplicitExpr()
         {
             Assert.AreEqual(LongV.Of(10), (Expr)10);
             Assert.AreEqual(LongV.Of(10), (Expr)10L);
@@ -22,10 +23,59 @@ namespace Test
             Assert.AreEqual(StringV.Of("millisecond"), (Expr)TimeUnit.Millisecond);
             Assert.AreEqual(StringV.Of("microsecond"), (Expr)TimeUnit.Microsecond);
             Assert.AreEqual(StringV.Of("nanosecond"), (Expr)TimeUnit.Nanosecond);
+            Assert.AreEqual(DateV.Of("2000-01-01"), (Expr)new DateTime(2000,1, 1, 0, 0, 0, DateTimeKind.Utc));
+            Assert.AreEqual(DateV.Of("2000-01-01"), (Expr)new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            Assert.AreEqual(TimeV.Of("2000-01-01T01:01:01.123Z"), (Expr)new DateTime(2000, 1, 1, 1, 1, 1, 123, DateTimeKind.Utc));
+            Assert.AreEqual(TimeV.Of("2000-01-01T01:01:01.123Z"), (Expr)new DateTimeOffset(2000, 1, 1, 1, 1, 1, 123, TimeSpan.Zero));
             Assert.AreEqual(NullV.Instance, (Expr)(string)null);
         }
 
-        [Test] public void TestExplicit()
+        [Test]
+        public void TestImplicitValue()
+        {
+            Assert.AreEqual(LongV.Of(10), (Value)10);
+            Assert.AreEqual(LongV.Of(10), (Value)10L);
+            Assert.AreEqual(BooleanV.True, (Value)true);
+            Assert.AreEqual(BooleanV.False, (Value)false);
+            Assert.AreEqual(DoubleV.Of(3.14), (Value)3.14);
+            Assert.AreEqual(StringV.Of("a string"), (Value)"a string");
+            Assert.AreEqual(StringV.Of("create"), (Value)ActionType.Create);
+            Assert.AreEqual(StringV.Of("delete"), (Value)ActionType.Delete);
+            Assert.AreEqual(StringV.Of("second"), (Value)TimeUnit.Second);
+            Assert.AreEqual(StringV.Of("millisecond"), (Value)TimeUnit.Millisecond);
+            Assert.AreEqual(StringV.Of("microsecond"), (Value)TimeUnit.Microsecond);
+            Assert.AreEqual(StringV.Of("nanosecond"), (Value)TimeUnit.Nanosecond);
+            Assert.AreEqual(DateV.Of("2000-01-01"), (Value)new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+            Assert.AreEqual(DateV.Of("2000-01-01"), (Value)new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero));
+            Assert.AreEqual(TimeV.Of("2000-01-01T01:01:01.123Z"), (Value)new DateTime(2000, 1, 1, 1, 1, 1, 123, DateTimeKind.Utc));
+            Assert.AreEqual(TimeV.Of("2000-01-01T01:01:01.123Z"), (Value)new DateTimeOffset(2000, 1, 1, 1, 1, 1, 123, TimeSpan.Zero));
+            Assert.AreEqual(NullV.Instance, (Value)(string)null);
+        }
+
+
+        [Test]
+        public void TestExplicitExpr()
+        {
+            Assert.AreEqual(10, (int)(Expr)LongV.Of(10));
+            Assert.AreEqual(10L, (long)(Expr)LongV.Of(10));
+            Assert.AreEqual(true, (bool)(Expr)BooleanV.True);
+            Assert.AreEqual(false, (bool)(Expr)BooleanV.False);
+            Assert.AreEqual(3.14, (double)(Expr)DoubleV.Of(3.14));
+            Assert.AreEqual("a string", (string)(Expr)StringV.Of("a string"));
+            Assert.AreEqual(ActionType.Create, (ActionType)(Expr)StringV.Of("create"));
+            Assert.AreEqual(ActionType.Delete, (ActionType)(Expr)StringV.Of("delete"));
+            Assert.AreEqual(TimeUnit.Second, (TimeUnit)(Expr)StringV.Of("second"));
+            Assert.AreEqual(TimeUnit.Millisecond, (TimeUnit)(Expr)StringV.Of("millisecond"));
+            Assert.AreEqual(TimeUnit.Microsecond, (TimeUnit)(Expr)StringV.Of("microsecond"));
+            Assert.AreEqual(TimeUnit.Nanosecond, (TimeUnit)(Expr)StringV.Of("nanosecond"));
+            Assert.AreEqual(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc), (DateTime)(Expr)DateV.Of("2000-01-01"));
+            Assert.AreEqual(new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero), (DateTimeOffset)(Expr)DateV.Of("2000-01-01"));
+            Assert.AreEqual(new DateTime(2000, 1, 1, 1, 1, 1, 123, DateTimeKind.Utc), (DateTime)(Expr)TimeV.Of("2000-01-01T01:01:01.123Z"));
+            Assert.AreEqual(new DateTimeOffset(2000, 1, 1, 1, 1, 1, 123, TimeSpan.Zero), (DateTimeOffset)(Expr)TimeV.Of("2000-01-01T01:01:01.123Z"));
+            Assert.AreEqual(null, (string)(Expr)NullV.Instance);
+        }
+
+        [Test] public void TestExplicitValue()
         {
             Assert.AreEqual(10, (int)LongV.Of(10));
             Assert.AreEqual(10L, (long)LongV.Of(10));
@@ -39,7 +89,10 @@ namespace Test
             Assert.AreEqual(TimeUnit.Millisecond, (TimeUnit)StringV.Of("millisecond"));
             Assert.AreEqual(TimeUnit.Microsecond, (TimeUnit)StringV.Of("microsecond"));
             Assert.AreEqual(TimeUnit.Nanosecond, (TimeUnit)StringV.Of("nanosecond"));
-            Assert.AreEqual(null, (string)(Expr)NullV.Instance);
+            Assert.AreEqual(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc), (DateTime)DateV.Of("2000-01-01"));
+            Assert.AreEqual(new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero), (DateTimeOffset)DateV.Of("2000-01-01"));
+            Assert.AreEqual(new DateTime(2000, 1, 1, 1, 1, 1, 123, DateTimeKind.Utc), (DateTime)TimeV.Of("2000-01-01T01:01:01.123Z"));
+            Assert.AreEqual(new DateTimeOffset(2000, 1, 1, 1, 1, 1, 123, TimeSpan.Zero), (DateTimeOffset)TimeV.Of("2000-01-01T01:01:01.123Z"));
         }
     }
 }

--- a/FaunaDB.Client.Test/SerializationTest.cs
+++ b/FaunaDB.Client.Test/SerializationTest.cs
@@ -784,8 +784,10 @@ namespace Test
             AssertJsonEqual(Query(Lambda("x", Add(Var("x"), 1))), "{\"query\":{\"lambda\":\"x\",\"expr\":{\"add\":[{\"var\":\"x\"},1]}}}");
             AssertJsonEqual(Query(Lambda(x => Add(x, 1))), "{\"query\":{\"lambda\":\"x\",\"expr\":{\"add\":[{\"var\":\"x\"},1]}}}");
 
-            AssertJsonEqual(QueryV.Of("x", Add(Var("x"), 1)), "{\"@query\":{\"lambda\":\"x\",\"expr\":{\"add\":[{\"var\":\"x\"},1]}}}");
-            AssertJsonEqual(QueryV.Of(x => Add(x, 1)), "{\"@query\":{\"lambda\":\"x\",\"expr\":{\"add\":[{\"var\":\"x\"},1]}}}");
+            AssertJsonEqual(
+                new QueryV(new Dictionary<string, Expr> { { "lambda", "x" }, { "expr", Add(Var("x"), 1) } }),
+                "{\"@query\":{\"lambda\":\"x\",\"expr\":{\"add\":[{\"var\":\"x\"},1]}}}"
+            );
         }
     }
 }

--- a/FaunaDB.Client/Properties/AssemblyInfo.cs
+++ b/FaunaDB.Client/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 
 // Information about this assembly is defined by the following attributes.
 // Change them to the values specific to your project.
@@ -13,6 +14,7 @@
 
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
+[assembly: InternalsVisibleTo("FaunaDB.Client.Test")]
 #else
 [assembly: AssemblyConfiguration("Release")]
 #endif

--- a/FaunaDB.Client/Query/Expr.Operators.cs
+++ b/FaunaDB.Client/Query/Expr.Operators.cs
@@ -23,6 +23,12 @@ namespace FaunaDB.Query
         public static implicit operator Expr(string s) =>
             s == null ? NullV.Instance : StringV.Of(s);
 
+        public static implicit operator Expr(DateTime dt) =>
+            Value.FromDateTime(dt);
+
+        public static implicit operator Expr(DateTimeOffset dt) =>
+            Value.FromDateTimeOffset(dt);
+
         public static implicit operator Expr(ActionType action)
         {
             switch (action)
@@ -70,6 +76,38 @@ namespace FaunaDB.Query
 
         public static explicit operator string(Expr v) =>
             v == NullV.Instance ? null : ((StringV)v).Value;
+
+        public static explicit operator DateTime(Expr v) =>
+            ToDateTime(v);
+
+        public static explicit operator DateTimeOffset(Expr v) =>
+            ToDateTimeOffset(v);
+
+        internal static DateTime ToDateTime(Expr v)
+        {
+            var date = v as DateV;
+            if (date != null)
+                return date.Value;
+
+            var time = v as TimeV;
+            if (time != null)
+                return time.Value;
+
+            throw new ArgumentException($"Cannot convert {v} to DateTime");
+        }
+
+        internal static DateTimeOffset ToDateTimeOffset(Expr v)
+        {
+            var date = v as DateV;
+            if (date != null)
+                return date.DateTimeOffset;
+
+            var time = v as TimeV;
+            if (time != null)
+                return time.DateTimeOffset;
+
+            throw new ArgumentException($"Cannot convert {v} to DateTimeOffset");
+        }
 
         public static explicit operator ActionType(Expr v)
         {

--- a/FaunaDB.Client/Types/BytesV.cs
+++ b/FaunaDB.Client/Types/BytesV.cs
@@ -16,13 +16,13 @@ namespace FaunaDB.Types
         /// <summary>
         /// Creates a new instance of <see cref="BytesV"/> from a base64 string.
         /// </summary>
-        public BytesV(string base64) : base(FromUrlSafeBase64(base64))
+        internal BytesV(string base64) : base(FromUrlSafeBase64(base64))
         { }
 
         /// <summary>
         /// Creates a new instance of <see cref="BytesV"/> from a variable lenght of bytes.
         /// </summary>
-        public BytesV(params byte[] value) : base(value)
+        internal BytesV(params byte[] value) : base(value)
         { }
 
         public static BytesV Of(string base64) =>

--- a/FaunaDB.Client/Types/Decoder.cs
+++ b/FaunaDB.Client/Types/Decoder.cs
@@ -130,6 +130,9 @@ namespace FaunaDB.Types
                     return null;
 
                 case TypeCode.Object:
+                    if (typeof(DateTimeOffset) == dstType)
+                        return new DateTimeOffset(ToDateTime(value));
+
                     if (typeof(byte[]) == dstType && value is BytesV)
                         return ToByteArray(value);
 
@@ -410,7 +413,7 @@ namespace FaunaDB.Types
                 .Where(p => p.CanWrite && !p.Has<FaunaIgnoreAttribute>())
                 .Select(p => Expression.Assign(Expression.MakeMemberAccess(varExpr, p), CallDecode(CallGetValue(objExpr, p, p.PropertyType), p.PropertyType)));
 
-            return properties.Count() > 0
+            return properties.Any()
                              ? Expression.Block(fields.Concat(properties))
                              : (Expression)Expression.Empty();
         }

--- a/FaunaDB.Client/Types/Encoder.cs
+++ b/FaunaDB.Client/Types/Encoder.cs
@@ -85,7 +85,7 @@ namespace FaunaDB.Types
                     return BooleanV.Of((bool)obj);
 
                 case TypeCode.DateTime:
-                    return WrapDateTime((DateTime)obj);
+                    return Value.FromDateTime((DateTime)obj);
 
                 case TypeCode.SByte:
                 case TypeCode.Int16:
@@ -110,6 +110,9 @@ namespace FaunaDB.Types
                     return NullV.Instance;
 
                 case TypeCode.Object:
+                    if (typeof(DateTimeOffset).IsInstanceOfType(obj))
+                        return Value.FromDateTimeOffset((DateTimeOffset)obj);
+
                     if (typeof(byte[]).IsInstanceOfType(obj))
                         return new BytesV((byte[])obj);
 
@@ -123,14 +126,6 @@ namespace FaunaDB.Types
             }
 
             throw new InvalidOperationException($"Unsupported type {type} at `{obj}`");
-        }
-
-        Value WrapDateTime(DateTime date)
-        {
-            if (date.Ticks % (24 * 60 * 60 * 10000) > 0)
-                return new TimeV(date);
-
-            return new DateV(date);
         }
 
         Value WrapEnumerable(IEnumerable array)

--- a/FaunaDB.Client/Types/Json.cs
+++ b/FaunaDB.Client/Types/Json.cs
@@ -4,6 +4,8 @@ using FaunaDB.Errors;
 using FaunaDB.Query;
 using Newtonsoft.Json;
 
+using static System.Linq.Enumerable;
+
 namespace FaunaDB.Types
 {
     class ValueJsonConverter : JsonConverter
@@ -171,8 +173,13 @@ namespace FaunaDB.Types
             }
         }
 
-        Expr ReadEnclosedLambda() =>
-            Unwrap(ReadEnclosedObject());
+        IReadOnlyDictionary<string, Expr> ReadEnclosedLambda()
+        {
+            return ReadEnclosedObject().Value.ToDictionary(
+                key => key.Key,
+                value => Unwrap(value.Value)
+            );
+        }
 
         static Expr Unwrap(Expr expr)
         {

--- a/FaunaDB.Client/Types/NullV.cs
+++ b/FaunaDB.Client/Types/NullV.cs
@@ -10,7 +10,7 @@ namespace FaunaDB.Types
     {
         public static readonly Value Instance = new NullV();
 
-        NullV() {}
+        internal NullV() {}
 
         protected internal override void WriteJson(JsonWriter writer)
         {

--- a/FaunaDB.Client/Types/QueryV.cs
+++ b/FaunaDB.Client/Types/QueryV.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using FaunaDB.Collections;
 using FaunaDB.Query;
 using Newtonsoft.Json;
 
@@ -10,66 +12,23 @@ namespace FaunaDB.Types
     /// See <see href="https://fauna.com/documentation/queries#values-special_types">FaunaDB Special Types</see>.
     /// </para>
     /// </summary>
-    public class QueryV : ScalarValue<Expr>
+    public class QueryV : ScalarValue<IReadOnlyDictionary<string, Expr>>
     {
-        internal QueryV(Expr lambda)
+        internal QueryV(IReadOnlyDictionary<string, Expr> lambda)
             : base(lambda) { }
-
-        /// <summary>
-        /// Creates a QueryV type from raw parameters.
-        /// <see cref="Language.Lambda(Expr, Expr)"/>
-        /// </summary>
-        public static QueryV Of(Expr vars, Expr expr) =>
-            new QueryV(Language.Lambda(vars, expr));
-
-        /// <summary>
-        /// Creates a QueryV type from a lambda that receives one argument.
-        /// <see cref="Language.Lambda(Func{Expr, Expr})"/>
-        /// </summary>
-        public static QueryV Of(Func<Expr, Expr> lambda) =>
-            new QueryV(Language.Lambda(lambda));
-
-        /// <summary>
-        /// Creates a QueryV type from a lambda that receives two arguments.
-        /// <see cref="Language.Lambda(Func{Expr, Expr, Expr})"/>
-        /// </summary>
-        public static QueryV Of(Func<Expr, Expr, Expr> lambda) =>
-            new QueryV(Language.Lambda(lambda));
-
-        /// <summary>
-        /// Creates a QueryV type from a lambda that receives three arguments.
-        /// <see cref="Language.Lambda(Func{Expr, Expr, Expr, Expr})"/>
-        /// </summary>
-        public static QueryV Of(Func<Expr, Expr, Expr, Expr> lambda) =>
-            new QueryV(Language.Lambda(lambda));
-
-        /// <summary>
-        /// Creates a QueryV type from a lambda that receives four arguments.
-        /// <see cref="Language.Lambda(Func{Expr, Expr, Expr, Expr, Expr})"/>
-        /// </summary>
-        public static QueryV Of(Func<Expr, Expr, Expr, Expr, Expr> lambda) =>
-            new QueryV(Language.Lambda(lambda));
-
-        /// <summary>
-        /// Creates a QueryV type from a lambda that receives five arguments.
-        /// <see cref="Language.Lambda(Func{Expr, Expr, Expr, Expr, Expr, Expr})"/>
-        /// </summary>
-        public static QueryV Of(Func<Expr, Expr, Expr, Expr, Expr, Expr> lambda) =>
-            new QueryV(Language.Lambda(lambda));
-
-        /// <summary>
-        /// Creates a QueryV type from a lambda that receives six arguments.
-        /// <see cref="Language.Lambda(Func{Expr, Expr, Expr, Expr, Expr, Expr, Expr})"/>
-        /// </summary>
-        public static QueryV Of(Func<Expr, Expr, Expr, Expr, Expr, Expr, Expr> lambda) =>
-            new QueryV(Language.Lambda(lambda));
 
         protected internal override void WriteJson(JsonWriter writer)
         {
             writer.WriteStartObject();
             writer.WritePropertyName("@query");
-            Value.WriteJson(writer);
+            writer.WriteObject(Value);
             writer.WriteEndObject();
+        }
+
+        public override bool Equals(Expr v)
+        {
+            var w = v as QueryV;
+            return w != null && Value.DictEquals(w.Value);
         }
     }
 }

--- a/FaunaDB.Client/Types/Value.cs
+++ b/FaunaDB.Client/Types/Value.cs
@@ -158,6 +158,27 @@ namespace FaunaDB.Types
         public static implicit operator Value(string s) =>
             s == null ? NullV.Instance : new StringV(s);
 
+        public static implicit operator Value(DateTime dt) =>
+            FromDateTime(dt);
+
+        public static implicit operator Value(DateTimeOffset dt) =>
+            FromDateTimeOffset(dt);
+
+        internal static Value FromDateTime(DateTime dt)
+        {
+            if (dt.Ticks % (24 * 60 * 60 * 10000) > 0)
+                return new TimeV(dt);
+
+            return new DateV(dt);
+        }
+
+        internal static Value FromDateTimeOffset(DateTimeOffset dt)
+        {
+            if (dt.UtcTicks % (24 * 60 * 60 * 10000) > 0)
+                return new TimeV(dt.UtcDateTime);
+
+            return new DateV(dt.UtcDateTime);
+        }
         #endregion
 
         #region explicit (downcasting) conversions
@@ -172,6 +193,12 @@ namespace FaunaDB.Types
 
         public static explicit operator string(Value v) =>
             ((StringV)v).Value;
+
+        public static explicit operator DateTime(Value v) =>
+            Expr.ToDateTime(v);
+
+        public static explicit operator DateTimeOffset(Value v) =>
+            Expr.ToDateTimeOffset(v);
         #endregion
     }
 


### PR DESCRIPTION
The list of improvements include:

* Adds support for `DateTimeOffset` class
* Make some values constructor internal, so it disencourage users to instantiate it
* Change `QueryV` to receive a dictionary as in other drivers and not an `Expr`
* Add more tests for implicit/explicit conversion

closes https://github.com/fauna/faunadb-csharp/issues/54