### PR TITLE
Add codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+---
+coverage:
+  notify:
+    slack:
+      default:
+        url: secret:5INxut+lquhI5hjgqoZYS2R9b+EUIULwXbJ5HRj18s2pMp56END3yqOcmL1TWGp2tYZlUaWdvJGc8BdbtE6OJT4T0GTlvkC6WT0sZQLHHrQWPjjUGuFf1o13KEbYgHCjCqVRoDiqWwOMFEKrXD1unGpJoD06zwzbCQl5KkhPnVo=


### PR DESCRIPTION
All the config to support coverage is done directly in Jenkins (due to how we run Jenkins, the config became machine-specific, so I just installed OpenCover/codecov on the build machine directly).