### PR TITLE
Adds is_empty/is_nonempty functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## 2.0.1-alpha
+## 2.1.0-alpha
+- Adds `IsEmpty()` and `IsNonEmpty()` function
 
 ## 2.0.0
 

--- a/FaunaDB.Client.Test/ClientTest.cs
+++ b/FaunaDB.Client.Test/ClientTest.cs
@@ -675,6 +675,24 @@ namespace Test
                         Is.EquivalentTo(new List<long> { 1L, 2L, 3L, 4L }));
         }
 
+        [Test] public async Task TestIsEmpty()
+        {
+            Assert.True((await client.Query(IsEmpty(Arr()))).To<bool>().Value);
+            Assert.False((await client.Query(IsEmpty(Arr(1, 2, 3)))).To<bool>().Value);
+
+            Assert.True((await client.Query(IsEmpty(Paginate(Match(Index("spells_by_element"), "iron"))))).To<bool>().Value);
+            Assert.False((await client.Query(IsEmpty(Paginate(Match(Index("spells_by_element"), "fire"))))).To<bool>().Value);
+        }
+
+        [Test] public async Task TestIsNonEmpty()
+        {
+            Assert.False((await client.Query(IsNonEmpty(Arr()))).To<bool>().Value);
+            Assert.True((await client.Query(IsNonEmpty(Arr(1, 2, 3)))).To<bool>().Value);
+
+            Assert.False((await client.Query(IsNonEmpty(Paginate(Match(Index("spells_by_element"), "iron"))))).To<bool>().Value);
+            Assert.True((await client.Query(IsNonEmpty(Paginate(Match(Index("spells_by_element"), "fire"))))).To<bool>().Value);
+        }
+
         [Test] public async Task TestReadEventsFromIndex()
         {
             Value events = await client.Query(

--- a/FaunaDB.Client.Test/FaunaDB.Client.Test.csproj
+++ b/FaunaDB.Client.Test/FaunaDB.Client.Test.csproj
@@ -13,13 +13,8 @@
      net46         => netstandard 1.0, 1.1, 1.2, 1.3
      net461        => netstandard 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 2.0
      -->
-    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;net45;net451;net46;net461;net47</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;net451;net46;net461;net47</TargetFrameworks>
   </PropertyGroup>
-
-  <Target Name="CopyConfig" AfterTargets="AfterBuild">
-    <Warning Text="Copying testConfig.json to $(OutputPath)" />
-    <Copy SourceFiles="testConfig.json" DestinationFolder="$(OutputPath)" />
-  </Target>
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.9.0" />

--- a/FaunaDB.Client.Test/SerializationTest.cs
+++ b/FaunaDB.Client.Test/SerializationTest.cs
@@ -247,6 +247,18 @@ namespace Test
                 "{\"append\":[1,2,3],\"collection\":[4,5,6]}");
         }
 
+        [Test] public void TestIsEmpty()
+        {
+            AssertJsonEqual(IsEmpty(Arr(1, 2, 3)),
+                "{\"is_empty\":[1,2,3]}");
+        }
+
+        [Test] public void TestIsNonEmpty()
+        {
+            AssertJsonEqual(IsNonEmpty(Arr(1, 2, 3)),
+                "{\"is_nonempty\":[1,2,3]}");
+        }
+
         [Test] public void TestGet()
         {
             AssertJsonEqual(Get(Ref(Class("thing"), "123456789")),

--- a/FaunaDB.Client.Test/TestCase.cs
+++ b/FaunaDB.Client.Test/TestCase.cs
@@ -34,12 +34,10 @@ namespace Test
             Func<string, string, string> Env = (name, @default) =>
                 Environment.GetEnvironmentVariable(name) ?? @default;
 
-            var cfg = await Config.GetConfig();
-
-            var domain = Env("FAUNA_DOMAIN", cfg.Domain);
-            var scheme = Env("FAUNA_SCHEME", cfg.Scheme);
-            var port = Env("FAUNA_PORT", cfg.Port);
-            var secret = Env("FAUNA_ROOT_KEY", cfg.Secret);
+            var domain = Env("FAUNA_DOMAIN", "localhost");
+            var scheme = Env("FAUNA_SCHEME", "http");
+            var port = Env("FAUNA_PORT", "8443");
+            var secret = Env("FAUNA_ROOT_KEY", "secret");
             var endpoint = $"{scheme}://{domain}:{port}";
 
             rootClient = new FaunaClient(secret: secret, endpoint: endpoint);
@@ -92,31 +90,5 @@ namespace Test
 
         public Task<RequestResult> DoRequest(HttpMethodKind method, string path, string data, IReadOnlyDictionary<string, string> query = null) =>
             Task.FromResult(resp);
-    }
-
-    // Use a class to make conversion from Json easier.
-    class Config {
-        public static async Task<Config> GetConfig()
-        {
-            var directory = Directory.GetCurrentDirectory();
-
-            var config = Directory.GetFiles(directory, "testConfig.json", SearchOption.AllDirectories);
-
-            if (config.Length > 0)
-            {
-                var text = await File.OpenText(config[0]).ReadToEndAsync();
-                return JsonConvert.DeserializeObject<Config>(text);
-            }
-
-            throw new Exception("testConfig.json not found");
-        }
-
-        public string Domain { get; set; }
-        public string Scheme { get; set; }
-        public string Port { get; set; }
-        public string Secret { get; set; }
-
-        public override string ToString() =>
-            $"Config(domain: {Domain}, scheme: {Scheme}, port: {Port}, secret: {Secret})";
     }
 }

--- a/FaunaDB.Client.Test/testConfig.json
+++ b/FaunaDB.Client.Test/testConfig.json
@@ -1,6 +1,0 @@
-{
-  "domain": "localhost",
-  "scheme": "http",
-  "port": "8443",
-  "secret": "secret"
-}

--- a/FaunaDB.Client/FaunaDB.Client.csproj
+++ b/FaunaDB.Client/FaunaDB.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net45;net451;net46;net461;net47</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.5;netstandard2.0;net451;net46;net461;net47</TargetFrameworks>
     <PackageVersion>2.0.1-alpha</PackageVersion>
     <PackageId>FaunaDB.Client</PackageId>
     <Title>C# Driver for FaunaDB</Title>

--- a/FaunaDB.Client/Query/Language.Collection.cs
+++ b/FaunaDB.Client/Query/Language.Collection.cs
@@ -153,5 +153,39 @@
         /// </example>
         public static Expr Append(Expr elements, Expr collection) =>
             UnescapedObject.With("append", elements, "collection", collection);
+
+        /// <summary>
+        /// Creates a new IsEmpty expression.
+        /// <para>
+        /// <see href="https://fauna.com/documentation/queries#collection_functions">FaunaDB Collection Functions</see>
+        /// </para>
+        /// </summary>
+        /// <param name="collection">A collection expression</param>
+        /// <example>
+        /// <code>
+        /// var result = await client.Query(IsEmpty(Arr(4, 5, 6)));
+        ///
+        /// Assert.AreEqual(false, result.To<bool>().Value);
+        /// </code>
+        /// </example>
+        public static Expr IsEmpty(Expr collection) =>
+            UnescapedObject.With("is_empty", collection);
+
+        /// <summary>
+        /// Creates a new IsNonEmpty expression.
+        /// <para>
+        /// <see href="https://fauna.com/documentation/queries#collection_functions">FaunaDB Collection Functions</see>
+        /// </para>
+        /// </summary>
+        /// <param name="collection">A collection expression</param>
+        /// <example>
+        /// <code>
+        /// var result = await client.Query(IsNonEmpty(Arr(4, 5, 6)));
+        ///
+        /// Assert.AreEqual(true, result.To<bool>().Value);
+        /// </code>
+        /// </example>
+        public static Expr IsNonEmpty(Expr collection) =>
+            UnescapedObject.With("is_nonempty", collection);
     }
 }


### PR DESCRIPTION
Along with that, I had to make some environmental changes as it was not working with the latest version of mono.

First, because the default target framework for Visual Studio is the first framework that appears in the list `TargetFrameworks` of the project it was causing the unit tests to run with `netcoreapp1.0`. Apparently there is a limitation in VS, so that was causing the test list to show empty in the IDE. So I moved `net45` to the first element in that list.

Second, I removed the config file `testConfig.json` and make its purely hard coded case there wasn't an env variable for that.