### PR TITLE
Add conversion functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.0-alpha
 - Adds `IsEmpty()` and `IsNonEmpty()` function
 - Adds `NGram()` function
+- Adds `ToStringExpr()`, `ToNumber()`, `ToTime()`, and `ToDate()` functions
 
 ## 2.0.0
 

--- a/FaunaDB.Client.Test/ClientTest.cs
+++ b/FaunaDB.Client.Test/ClientTest.cs
@@ -938,6 +938,30 @@ namespace Test
             Assert.AreEqual(true, notR.To<bool>().Value);
         }
 
+        [Test] public async Task TestEvalToStringExpression()
+        {
+            Value str = await client.Query(ToStringExpr(42));
+            Assert.AreEqual("42", str.To<string>().Value);
+        }
+
+        [Test] public async Task TestEvalToNumberExpression()
+        {
+            Value num = await client.Query(ToNumber("42"));
+            Assert.AreEqual(42, num.To<long>().Value);
+        }
+
+        [Test] public async Task TestEvalToTimeExpression()
+        {
+            Value time = await client.Query(ToTime("1970-01-01T00:00:00Z"));
+            Assert.AreEqual(new DateTime(1970, 1, 1, 0, 0, 0), time.To<DateTime>().Value);
+        }
+
+        [Test] public async Task TestEvalToDateExpression()
+        {
+            Value date = await client.Query(ToDate("1970-01-01"));
+            Assert.AreEqual(new DateTime(1970, 1, 1), date.To<DateTime>().Value);
+        }
+
         [Test] public async Task TestEvalTimeExpression()
         {
             Value res = await client.Query(Time("1970-01-01T00:00:00-04:00"));

--- a/FaunaDB.Client.Test/SerializationTest.cs
+++ b/FaunaDB.Client.Test/SerializationTest.cs
@@ -755,6 +755,27 @@ namespace Test
             AssertJsonEqual(Not(false), "{\"not\":false}");
         }
 
+        [Test] public void TestToStringExpr()
+        {
+            AssertJsonEqual(ToStringExpr(42), "{\"to_string\":42}");
+        }
+
+        [Test] public void TestToNumber()
+        {
+            AssertJsonEqual(ToNumber("42"), "{\"to_number\":\"42\"}");
+        }
+
+        [Test] public void TestToTime()
+        {
+            AssertJsonEqual(ToTime("1970-01-01T00:00:00Z"),
+                            "{\"to_time\":\"1970-01-01T00:00:00Z\"}");
+        }
+
+        [Test] public void TestToDate()
+        {
+            AssertJsonEqual(ToDate("1970-01-01"), "{\"to_date\":\"1970-01-01\"}");
+        }
+
         [Test]
         public void TestInstanceRef()
         {

--- a/FaunaDB.Client/Query/Language.Miscellaneous.cs
+++ b/FaunaDB.Client/Query/Language.Miscellaneous.cs
@@ -293,5 +293,29 @@ namespace FaunaDB.Query
         /// </summary>
         public static Expr Not(Expr boolean) =>
             UnescapedObject.With("not", boolean);
+
+        /// <summary>
+        ///   Converts an expression to a string literal.
+        /// </summary>
+        public static Expr ToStringExpr(Expr expr) =>
+            UnescapedObject.With("to_string", expr);
+
+        /// <summary>
+        ///   Converts an expression to a number literal.
+        /// </summary>
+        public static Expr ToNumber(Expr expr) =>
+            UnescapedObject.With("to_number", expr);
+
+        /// <summary>
+        ///   Converts an expresion to a time literal.
+        /// </summary>
+        public static Expr ToTime(Expr expr) =>
+            UnescapedObject.With("to_time", expr);
+
+        /// <summary>
+        ///   Converts an expression to a date literal.
+        /// </summary>
+        public static Expr ToDate(Expr expr) =>
+            UnescapedObject.With("to_date", expr);
     }
 }


### PR DESCRIPTION
`ToString()` is C#'s version of Java's `toString()`, so we cannot override it in a static class.