### PR TITLE
DRV-90: Feature to enforce DateV and TimeV for encoder plus DateTimeExtensions

### DIFF
--- a/FaunaDB.Client.Test/EncoderTest.cs
+++ b/FaunaDB.Client.Test/EncoderTest.cs
@@ -325,5 +325,30 @@ namespace Test
             Assert.AreEqual(StringV.Of("ARM"), Encode(CpuTypes.ARM));
             Assert.AreEqual(StringV.Of("MIPS"), Encode(CpuTypes.MIPS));
         }
+        class DateTimeOverride
+        {
+            [FaunaField("timev")]
+            [FaunaTime]
+            public DateTime TimeV { get; set; }
+
+            [FaunaField("datev")]
+            [FaunaDate]
+            public DateTime DateV { get; set; }
+
+            public DateTimeOverride(DateTime timeV, DateTime dateV)
+            {
+                this.TimeV = timeV;
+                this.DateV = dateV;
+            }
+        }
+        [Test]
+        public void TestDateTimeOverride()
+        {
+            DateTime testDateTime = new DateTime(2000, 1, 1, 1, 1, 1, 1);
+            Assert.AreEqual(
+                ObjectV.With("timev", new TimeV(testDateTime), "datev", new DateV(testDateTime.Date)),
+                Encode(new DateTimeOverride(testDateTime, testDateTime))
+            );
+        }
     }
 }

--- a/FaunaDB.Client.Test/EncoderTest.cs
+++ b/FaunaDB.Client.Test/EncoderTest.cs
@@ -325,6 +325,7 @@ namespace Test
             Assert.AreEqual(StringV.Of("ARM"), Encode(CpuTypes.ARM));
             Assert.AreEqual(StringV.Of("MIPS"), Encode(CpuTypes.MIPS));
         }
+
         class DateTimeOverride
         {
             [FaunaField("timev")]
@@ -341,6 +342,7 @@ namespace Test
                 this.DateV = dateV;
             }
         }
+
         [Test]
         public void TestDateTimeOverride()
         {

--- a/FaunaDB.Client/Types/Attributes.cs
+++ b/FaunaDB.Client/Types/Attributes.cs
@@ -55,16 +55,19 @@ namespace FaunaDB.Types
             Name = name;
         }
     }
+
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public class FaunaDate : Attribute
     {
 
     }
+
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public class FaunaTime : Attribute
     {
 
     }
+
     /// <summary>
     /// Instruct the encoder to not encode the specified member.
     /// </summary>

--- a/FaunaDB.Client/Types/Attributes.cs
+++ b/FaunaDB.Client/Types/Attributes.cs
@@ -49,13 +49,22 @@ namespace FaunaDB.Types
         /// The default value used for a missing property when decoding an object.
         /// </summary>
         public object DefaultValue { get; set; }
-
+        
         public FaunaFieldAttribute(string name)
         {
             Name = name;
         }
     }
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
+    public class FaunaDate : Attribute
+    {
 
+    }
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
+    public class FaunaTime : Attribute
+    {
+
+    }
     /// <summary>
     /// Instruct the encoder to not encode the specified member.
     /// </summary>

--- a/FaunaDB.Client/Types/Attributes.cs
+++ b/FaunaDB.Client/Types/Attributes.cs
@@ -56,17 +56,43 @@ namespace FaunaDB.Types
         }
     }
 
+    /// <summary>
+    /// Instruct the encoder that this <see cref="DateTime"/> property should always be
+    /// converted to <see cref="Types.DateV"/>
+    /// </summary>
+    /// <example>
+    /// class User
+    /// {
+    ///     [FaunaDate]
+    ///     public DateTime Birthday { get; set; }
+    /// }
+    ///
+    /// var user = new User { Birthday = DateTime.Now };
+    ///
+    /// var encoded = Encoder.Encode(user);
+    /// </example>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public class FaunaDate : Attribute
-    {
+    {}
 
-    }
-
+    /// <summary>
+    /// Instruct the encoder that this <see cref="DateTime"/> property should always be
+    /// converted to <see cref="Types.TimeV"/>
+    /// </summary>
+    /// <example>
+    /// class User
+    /// {
+    ///     [FaunaTime]
+    ///     public DateTime TimeSignedUp { get; set; }
+    /// }
+    ///
+    /// var user = new User { TimeSignedUp = DateTime.Now };
+    ///
+    /// var encoded = Encoder.Encode(user);
+    /// </example>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     public class FaunaTime : Attribute
-    {
-
-    }
+    {}
 
     /// <summary>
     /// Instruct the encoder to not encode the specified member.

--- a/FaunaDB.Client/Types/Encoder.cs
+++ b/FaunaDB.Client/Types/Encoder.cs
@@ -130,7 +130,7 @@ namespace FaunaDB.Types
 
                 case TypeCode.Object:
                     if (typeof(DateTimeOffset).IsInstanceOfType(obj))
-                        return Value.FromDateTimeOffset((DateTimeOffset)obj);
+                        return Value.FromDateTimeOffset((DateTimeOffset)obj, forceType);
 
                     if (typeof(byte[]).IsInstanceOfType(obj))
                         return new BytesV((byte[])obj);

--- a/FaunaDB.Client/Types/Encoder.cs
+++ b/FaunaDB.Client/Types/Encoder.cs
@@ -46,7 +46,7 @@ namespace FaunaDB.Types
 
         Stack<object> stack = new Stack<object>();
 
-        public Value Encode(object obj, Type t = null)
+        public Value Encode(object obj, Type type = null)
         {
             if (obj == null)
                 return NullV.Instance;
@@ -61,7 +61,7 @@ namespace FaunaDB.Types
             {
                 stack.Push(obj);
 
-                return EncodeIntern(obj, t);
+                return EncodeIntern(obj, type);
             }
             finally
             {

--- a/FaunaDB.Client/Types/Reflection.cs
+++ b/FaunaDB.Client/Types/Reflection.cs
@@ -43,7 +43,7 @@ namespace FaunaDB.Types
             var time = member.GetCustomAttribute<FaunaTime>();
 
             if (date != null && time != null)
-                throw (new InvalidOperationException("Can't use both FaunaDate and FaunaTime on the same property."));
+                throw new InvalidOperationException("Can't use both FaunaDate and FaunaTime on the same property.");
             
             if (time != null)
                 return typeof(TimeV);

--- a/FaunaDB.Client/Types/Reflection.cs
+++ b/FaunaDB.Client/Types/Reflection.cs
@@ -37,6 +37,22 @@ namespace FaunaDB.Types
             return member.Name;
         }
 
+        public static Type GetOverrideType(this MemberInfo member)
+        {
+            var date = member.GetCustomAttribute<FaunaDate>();
+            var time = member.GetCustomAttribute<FaunaTime>();
+
+            if (date != null && time != null)
+                throw (new InvalidOperationException("Can't use both FaunaDate and FaunaTime on the same property."));
+            
+            if (time != null)
+                return typeof(TimeV);
+            else if (date != null)
+                return typeof(DateV);
+
+            return null;
+        }
+
         public static bool Has<T>(this MemberInfo member) where T : Attribute =>
             member.GetCustomAttribute<T>() != null;
 

--- a/FaunaDB.Client/Types/Value.cs
+++ b/FaunaDB.Client/Types/Value.cs
@@ -164,20 +164,26 @@ namespace FaunaDB.Types
         public static implicit operator Value(DateTimeOffset dt) =>
             FromDateTimeOffset(dt);
 
-        internal static Value FromDateTime(DateTime dt)
+        internal static Value FromDateTime(DateTime dt, Type forceType = null)
         {
-            if (dt.Ticks % (24 * 60 * 60 * 10000) > 0)
+            if(forceType == typeof(DateV))
+                return new DateV(dt.Date);
+
+            if (forceType == typeof(TimeV) || dt.Ticks % (24 * 60 * 60 * 10000) > 0)
                 return new TimeV(dt);
 
-            return new DateV(dt);
+            return new DateV(dt.Date);
         }
 
-        internal static Value FromDateTimeOffset(DateTimeOffset dt)
+        internal static Value FromDateTimeOffset(DateTimeOffset dt, Type forceType = null)
         {
-            if (dt.UtcTicks % (24 * 60 * 60 * 10000) > 0)
+            if (forceType == typeof(DateV))
+                return new DateV(dt.UtcDateTime.Date);
+
+            if (forceType == typeof(TimeV) || dt.UtcTicks % (24 * 60 * 60 * 10000) > 0)
                 return new TimeV(dt.UtcDateTime);
 
-            return new DateV(dt.UtcDateTime);
+            return new DateV(dt.UtcDateTime.Date);
         }
         #endregion
 

--- a/FaunaDB.Client/Utils/DateTimeExtensions.cs
+++ b/FaunaDB.Client/Utils/DateTimeExtensions.cs
@@ -11,13 +11,14 @@ namespace FaunaDB.Client.Utils
         {
             return new Types.TimeV(dt);
         }
+
         /// <summary>
         /// Will return a Fauna <see cref="Types.DateV"/> object.
         /// </summary>
         /// <returns> <see cref="Types.DateV"/></returns>
         public static Types.DateV ToFaunaDate(this DateTime dt)
         {
-            return new Types.DateV(dt);
+            return new Types.DateV(dt.Date);
         }
 
         /// <summary>
@@ -28,13 +29,14 @@ namespace FaunaDB.Client.Utils
         {
             return new Types.TimeV(dt.UtcDateTime);
         }
+
         /// <summary>
         /// Will return a Fauna <see cref="Types.DateV"/> object.
         /// </summary>
         /// <returns> <see cref="Types.DateV"/></returns>
         public static Types.DateV ToFaunaDate(this DateTimeOffset dt)
         {
-            return new Types.DateV(dt.UtcDateTime);
+            return new Types.DateV(dt.UtcDateTime.Date);
         }
     }
 }

--- a/FaunaDB.Client/Utils/DateTimeExtensions.cs
+++ b/FaunaDB.Client/Utils/DateTimeExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+namespace FaunaDB.Client.Utils
+{
+    public static class DateTimeExtensions
+    {
+        /// <summary>
+        /// Will return a Fauna <see cref="Types.TimeV"/> object.
+        /// </summary>
+        /// <returns> <see cref="Types.TimeV"/></returns>
+        public static Types.TimeV ToFaunaTime(this DateTime dt)
+        {
+            return new Types.TimeV(dt);
+        }
+        /// <summary>
+        /// Will return a Fauna <see cref="Types.DateV"/> object.
+        /// </summary>
+        /// <returns> <see cref="Types.DateV"/></returns>
+        public static Types.DateV ToFaunaDate(this DateTime dt)
+        {
+            return new Types.DateV(dt);
+        }
+
+        /// <summary>
+        /// Will return a Fauna <see cref="Types.TimeV"/> object.
+        /// </summary>
+        /// <returns> <see cref="Types.TimeV"/></returns>
+        public static Types.TimeV ToFaunaTime(this DateTimeOffset dt)
+        {
+            return new Types.TimeV(dt.UtcDateTime);
+        }
+        /// <summary>
+        /// Will return a Fauna <see cref="Types.DateV"/> object.
+        /// </summary>
+        /// <returns> <see cref="Types.DateV"/></returns>
+        public static Types.DateV ToFaunaDate(this DateTimeOffset dt)
+        {
+            return new Types.DateV(dt.UtcDateTime);
+        }
+    }
+}


### PR DESCRIPTION
Spoke to Marrony Neris on community slack about the issue with Time equal to zero always causing DateTime to be converted into DateV even if you want TimeV. This PR has changed he suggest in PR#90 plus other on slack