### PR TITLE
DRV-47: Update C# driver to speak HTTP/2

### DIFF
--- a/FaunaDB.Client/Client/DefaultClientIO.cs
+++ b/FaunaDB.Client/Client/DefaultClientIO.cs
@@ -39,7 +39,11 @@ namespace FaunaDB.Client
             this.lastSeen = lastSeen;
             this.endpoint = endpoint;
             this.clientTimeout = timeout;
+#if NETSTANDARD2_1
+            this.httpVersion = httpVersion == null ? new Version(2, 0) : httpVersion;
+#else
             this.httpVersion = httpVersion == null ? new Version(1, 1) : httpVersion;
+#endif
         }
 
         public DefaultClientIO(string secret, Uri endpoint, TimeSpan? timeout = null, HttpClient httpClient = null, Version httpVersion = null)

--- a/FaunaDB.Client/Client/DefaultClientIO.cs
+++ b/FaunaDB.Client/Client/DefaultClientIO.cs
@@ -39,7 +39,7 @@ namespace FaunaDB.Client
             this.lastSeen = lastSeen;
             this.endpoint = endpoint;
             this.clientTimeout = timeout;
-            this.httpVersion = httpVersion == null ? HttpVersion.Version11 : httpVersion;
+            this.httpVersion = httpVersion == null ? new Version(1, 1) : httpVersion;
         }
 
         public DefaultClientIO(string secret, Uri endpoint, TimeSpan? timeout = null, HttpClient httpClient = null, Version httpVersion = null)
@@ -123,6 +123,7 @@ namespace FaunaDB.Client
             message.Headers.Add("X-FaunaDB-API-Version", "4");
             message.Headers.Add("X-Driver-Env", RuntimeEnvironmentHeader.Construct(EnvironmentEditor.Create()));
             message.Version = httpVersion;
+            message.SetTimeout(Timeout.InfiniteTimeSpan);
             
             var last = lastSeen.Txn;
             if (last.HasValue)
@@ -132,7 +133,7 @@ namespace FaunaDB.Client
 
             var httpResponse = await client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead, CancellationToken.None).ConfigureAwait(false);
             
-            Stream response = await httpResponse.Content.ReadAsStreamAsync();
+            Stream response = await httpResponse.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
             var endTime = DateTime.UtcNow;
 

--- a/FaunaDB.Client/Client/DefaultClientIO.cs
+++ b/FaunaDB.Client/Client/DefaultClientIO.cs
@@ -27,25 +27,27 @@ namespace FaunaDB.Client
         readonly AuthenticationHeaderValue authHeader;
 
         private LastSeen lastSeen;
+        private Version httpVersion;
 
         public const string StreamingPath = "stream";
         public const HttpMethodKind StreamingHttpMethod = HttpMethodKind.Post;
 
-        internal DefaultClientIO(HttpClient client, AuthenticationHeaderValue authHeader, LastSeen lastSeen, Uri endpoint, TimeSpan? timeout)
+        internal DefaultClientIO(HttpClient client, AuthenticationHeaderValue authHeader, LastSeen lastSeen, Uri endpoint, TimeSpan? timeout, Version httpVersion)
         {
             this.client = client;
             this.authHeader = authHeader;
             this.lastSeen = lastSeen;
             this.endpoint = endpoint;
             this.clientTimeout = timeout;
+            this.httpVersion = httpVersion == null ? HttpVersion.Version11 : httpVersion;
         }
 
-        public DefaultClientIO(string secret, Uri endpoint, TimeSpan? timeout = null, HttpClient httpClient = null)
-            : this(httpClient ?? CreateClient(), AuthHeader(secret), new LastSeen(), endpoint, timeout)
+        public DefaultClientIO(string secret, Uri endpoint, TimeSpan? timeout = null, HttpClient httpClient = null, Version httpVersion = null)
+            : this(httpClient ?? CreateClient(), AuthHeader(secret), new LastSeen(), endpoint, timeout, httpVersion)
         { }
 
         public IClientIO NewSessionClient(string secret) =>
-            new DefaultClientIO(client, AuthHeader(secret), lastSeen, endpoint, clientTimeout);
+            new DefaultClientIO(client, AuthHeader(secret), lastSeen, endpoint, clientTimeout, httpVersion);
 
         public Task<RequestResult> DoRequest(HttpMethodKind method, string path, string data, IReadOnlyDictionary<string, string> query = null, TimeSpan? queryTimeout = null) =>
             DoRequestAsync(method, path, data, query, queryTimeout);
@@ -69,6 +71,7 @@ namespace FaunaDB.Client
             message.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             message.Headers.Add("X-FaunaDB-API-Version", "4");
             message.Headers.Add("X-Driver-Env", RuntimeEnvironmentHeader.Construct(EnvironmentEditor.Create()));
+            message.Version = httpVersion;
 
             var last = lastSeen.Txn;
             if (last.HasValue)
@@ -119,6 +122,7 @@ namespace FaunaDB.Client
             message.Headers.Authorization = authHeader;
             message.Headers.Add("X-FaunaDB-API-Version", "4");
             message.Headers.Add("X-Driver-Env", RuntimeEnvironmentHeader.Construct(EnvironmentEditor.Create()));
+            message.Version = httpVersion;
             
             var last = lastSeen.Txn;
             if (last.HasValue)

--- a/FaunaDB.Client/Client/FaunaClient.cs
+++ b/FaunaDB.Client/Client/FaunaClient.cs
@@ -31,12 +31,14 @@ namespace FaunaDB.Client
         /// <param name="secret">Auth token for the FaunaDB server.</param>
         /// <param name="endpoint">URL for the FaunaDB server. Defaults to "https://db.fauna.com:443"</param>
         /// <param name="timeout">Timeout for I/O operations. Defaults to 1 minute.</param>
+        /// <param name="httpVersion">Version of http. Default value is HttpVersion.Version11, is you use .net core 3.0 and above you can enable http/2 support by passing HttpVersion.Version20</param>
         public FaunaClient(
             string secret,
             string endpoint = "https://db.fauna.com:443",
             TimeSpan? timeout = null,
-            HttpClient httpClient = null)
-            : this(CreateClient(secret, endpoint, timeout, httpClient))
+            HttpClient httpClient = null,
+            Version httpVersion = null)
+            : this(CreateClient(secret, endpoint, timeout, httpClient, httpVersion))
         { }
 
         /// <summary>
@@ -241,13 +243,15 @@ namespace FaunaDB.Client
             string secret,
             string endpoint,
             TimeSpan? timeout = null,
-            HttpClient httpClient = null)
+            HttpClient httpClient = null,
+            Version httpVersion = null)
         {
             return new DefaultClientIO(
                 secret: secret,
                 endpoint: new Uri(endpoint),
                 timeout: timeout,
-                httpClient: httpClient
+                httpClient: httpClient,
+                httpVersion: httpVersion
             );
         }
     }

--- a/FaunaDB.Client/FaunaDB.Client.csproj
+++ b/FaunaDB.Client/FaunaDB.Client.csproj
@@ -35,6 +35,6 @@ See https://fauna.com for more information.</Description>
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ We've also added an optional parameter if you want to specify the version of the
 var adminClient = new FaunaClient(
     endpoint: endpoint,
     secret: secret,
-    httpVersion: HttpVersion.Version20
+    httpVersion: HttpVersion.Version11
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ var client = new FaunaClient("secret", "http://localhost:9090/", httpClient: htt
 ```
 
 #### HTTP 2.0 support
-Starting from 4.0.0 version of the driver you have HTTP 2.0 support enabled by default for .net standard 2.1,  
-so if you use .net core 3.1 which supports that standard you'll be sending requests to faunadb server on HTTP 2.0  
-Standards lower than 2.1 as well as .net frameworks 4.5-4.8 have HTTP 1.1 as a default protocol version, since they lack of support for it.  
+Starting from version 4.0.0 of this driver (faunadb-csharp), HTTP/2 support is enabled by default for .NET standards 2.1 and above.
+This means that if you use .NET core 3.1 and above (which support that standard), you'll be sending requests to Fauna on HTTP/2. 
+.NET standards lower than 2.1 and .NET frameworks 4.5-4.8 have HTTP/1.1 enabled as the default protocol version, since they lack of support for HTTP/2.
 We've also added an optional parameter if you want to specify the version of the protocol directly:
 ```
 var adminClient = new FaunaClient(

--- a/README.md
+++ b/README.md
@@ -146,6 +146,19 @@ http.Timeout = TimeSpan.FromSeconds(15);
 var client = new FaunaClient("secret", "http://localhost:9090/", httpClient: http);
 ```
 
+#### HTTP 2.0 support
+Starting from 4.0.0 version of the driver you have HTTP 2.0 support enabled by default for .net standard 2.1,  
+so if you use .net core 3.1 which supports that standard you'll be sending requests to faunadb server on HTTP 2.0  
+Standards lower than 2.1 as well as .net frameworks 4.5-4.8 have HTTP 1.1 as a default protocol version, since they lack of support for it.  
+We've also added an optional parameter if you want to specify the version of the protocol directly:
+```
+var adminClient = new FaunaClient(
+    endpoint: endpoint,
+    secret: secret,
+    httpVersion: HttpVersion.Version20
+);
+```
+
 #### How to execute a query
 
 ```csharp

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Starting from version 4.0.0 of this driver (faunadb-csharp), HTTP/2 support is e
 This means that if you use .NET core 3.1 and above (which support that standard), you'll be sending requests to Fauna on HTTP/2. 
 .NET standards lower than 2.1 and .NET frameworks 4.5-4.8 have HTTP/1.1 enabled as the default protocol version, since they lack of support for HTTP/2.
 We've also added an optional parameter if you want to specify the version of the protocol directly:
-```
+```csharp
 var adminClient = new FaunaClient(
     endpoint: endpoint,
     secret: secret,


### PR DESCRIPTION
### Notes
Adds an optional parameter to FaunaClient, so user can support http version:
```
var client = new FaunaClient(endpoint: ENDPOINT, secret: SECRET, httpVersion: HttpVersion.Version20);
```

### Jira ticket
https://faunadb.atlassian.net/browse/DRV-47