### PR TITLE
object property mapping is now case insensitive

### DIFF
--- a/FaunaDB.Client/Types/ObjectV.cs
+++ b/FaunaDB.Client/Types/ObjectV.cs
@@ -36,7 +36,7 @@ namespace FaunaDB.Types
         /// </param>
         internal ObjectV(Action<Action<string, Value>> builder)
         {
-            var values = new Dictionary<string, Value>();
+            var values = new Dictionary<string, Value>( StringComparer.OrdinalIgnoreCase );
             builder((k, v) => values.Add(k, v));
             Value = values;
         }


### PR DESCRIPTION
This makes it possible to bind values to properties regardless of the casing, without the need to use the `FaunaField` attribute.

In sum.... this
```csharp
public class Store
{
    public string Name { get; set; }
}
```
instead of this
```csharp
public class Store
{
    [FaunaField( "name" ]
    public string Name { get; set; }
}
```