### PR TITLE
Added naming strategy for value encoder/decoder

### DIFF
--- a/FaunaDB.Client/Types/NamingStrategy.cs
+++ b/FaunaDB.Client/Types/NamingStrategy.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace FaunaDB.Types
+{
+    /// <summary>
+    /// Naming strategy for <see cref="Value"/> encoder/decoder.
+    /// </summary>
+    public abstract class NamingStrategy
+    {
+        public static NamingStrategy Default { get; set; } = new DefaultNamingStrategy();
+
+        public abstract string ResolvePropertyName(string name);
+    }
+
+    public sealed class DefaultNamingStrategy : NamingStrategy
+    {
+        public override string ResolvePropertyName(string name)
+        {
+            return name;
+        }
+    }
+
+    public sealed class CamelCaseNamingStrategy : NamingStrategy
+    {
+        public override string ResolvePropertyName(string name) =>
+            System.Text.RegularExpressions.Regex.Replace(name, @"([A-Z])([A-Z]+|[a-z0-9_]+)($|[A-Z]\w*)",
+                m =>
+                {
+                    return m.Groups[1].Value.ToLower() + m.Groups[2].Value.ToLower() + m.Groups[3].Value;
+                } );
+    }
+}

--- a/FaunaDB.Client/Types/ObjectV.cs
+++ b/FaunaDB.Client/Types/ObjectV.cs
@@ -36,7 +36,7 @@ namespace FaunaDB.Types
         /// </param>
         internal ObjectV(Action<Action<string, Value>> builder)
         {
-            var values = new Dictionary<string, Value>();
+            var values = new Dictionary<string, Value>( StringComparer.OrdinalIgnoreCase );
             builder((k, v) => values.Add(k, v));
             Value = values;
         }

--- a/FaunaDB.Client/Types/ObjectV.cs
+++ b/FaunaDB.Client/Types/ObjectV.cs
@@ -36,7 +36,7 @@ namespace FaunaDB.Types
         /// </param>
         internal ObjectV(Action<Action<string, Value>> builder)
         {
-            var values = new Dictionary<string, Value>( StringComparer.OrdinalIgnoreCase );
+            var values = new Dictionary<string, Value>();
             builder((k, v) => values.Add(k, v));
             Value = values;
         }

--- a/FaunaDB.Client/Types/Reflection.cs
+++ b/FaunaDB.Client/Types/Reflection.cs
@@ -19,7 +19,7 @@ namespace FaunaDB.Types
             return type.GetFields(flags).Concat(GetAllFields(type.GetTypeInfo().BaseType));
         }
 
-        public static string GetName(this ParameterInfo parameter)
+        public static string GetName(this ParameterInfo parameter, NamingStrategy namingStrategy)
         {
             var field = parameter.GetCustomAttribute<FaunaFieldAttribute>();
 
@@ -28,10 +28,10 @@ namespace FaunaDB.Types
                 return field.Name;
             }
 
-            return parameter.Name;
+            return namingStrategy.ResolvePropertyName(parameter.Name);
         }
 
-        public static string GetName(this MemberInfo member)
+        public static string GetName(this MemberInfo member, NamingStrategy namingStrategy)
         {
             var field = member.GetCustomAttribute<FaunaFieldAttribute>();
 
@@ -40,7 +40,7 @@ namespace FaunaDB.Types
                 return field.Name;
             }
 
-            return member.Name;
+            return namingStrategy.ResolvePropertyName(member.Name);
         }
 
         public static Type GetOverrideType(this ParameterInfo member)


### PR DESCRIPTION
The default naming strategy is to use the names of the properties as they are. In C# this is usually `TitleCase`. This adds a possibility to set a new naming strategy, either by using a different one per encoding/decoding request or by changing the default. This change adds `CamelCaseNamingStrategy` but it also adds the possibility to write a custom naming strategy by deriving from `NamingStrategy` abstract class.
This functionality doesn't change the behavior when `FaunaField` attributes are used.

Using the `CamelCaseNamingStrategy` explicitly on an encoding request
```csharp
var value = Encoder.Encode( obj, new CamelCaseNamingStrategy() );
```

Setting `CamelCaseNamingStrategy` as the default for every encoding/decoding request
```csharp
NamingStrategy.Default = new CamelCaseNamingStrategy();
```