### PR TITLE
feat(OSS-846): Added an optional customHeaders parameter for FaunaCli…

### DIFF
--- a/FaunaDB.Client.Test/ClientTest.cs
+++ b/FaunaDB.Client.Test/ClientTest.cs
@@ -234,8 +234,32 @@ namespace Test
         [Test]
         public async Task TestGetAnInstanceWithCustomHeaders()
         {
-            Value document = await clientWithCustomHeaders.Query(Get(magicMissile));
-            Assert.AreEqual("Magic Missile", document.Get(NAME_FIELD));
+            var clientWithCustomHeaders = new FaunaClient(
+                secret: faunaSecret,
+                endpoint: faunaEndpoint,
+                customHeaders: new Dictionary<string, string>
+                {
+                    { "test-header-1", "test-value-1" },
+                    { "test-header-2", "test-value-2" },
+                }
+            );
+
+            await clientWithCustomHeaders.Query(
+                CreateCollection(
+                    Obj("name", "magic_spells"))
+            );
+
+            var magicFireball = GetRef(await clientWithCustomHeaders.Query(
+                Create(Collection("magic_spells"),
+                    Obj("data",
+                        Obj(
+                            "name", "Fire Ball",
+                            "element", "arcane",
+                            "cost", 10)))
+            ));
+
+            Value document = await clientWithCustomHeaders.Query(Get(magicFireball));
+            Assert.AreEqual("Fire Ball", document.Get(NAME_FIELD));
         }
 
         [Test]

--- a/FaunaDB.Client.Test/ClientTest.cs
+++ b/FaunaDB.Client.Test/ClientTest.cs
@@ -232,6 +232,13 @@ namespace Test
         }
 
         [Test]
+        public async Task TestGetAnInstanceWithCustomHeaders()
+        {
+            Value document = await clientWithCustomHeaders.Query(Get(magicMissile));
+            Assert.AreEqual("Magic Missile", document.Get(NAME_FIELD));
+        }
+
+        [Test]
         public async Task TestIssueABatchedQueryWithVarargs()
         {
             var result0 = await client.Query(

--- a/FaunaDB.Client.Test/TestCase.cs
+++ b/FaunaDB.Client.Test/TestCase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -21,8 +22,10 @@ namespace Test
         protected static Field<RefV> REF_FIELD = Field.At("ref").To<RefV>();
 
         protected FaunaClient rootClient;
+        protected FaunaClient rootClientWithCustomHeaders;
         protected Expr DbRef;
         protected FaunaClient client;
+        protected FaunaClient clientWithCustomHeaders;
         protected FaunaClient adminClient;
         protected Value clientKey;
         protected Value adminKey;
@@ -50,6 +53,15 @@ namespace Test
             faunaSecret = env("FAUNA_ROOT_KEY", "secret");
             faunaEndpoint = port != "443" ? $"{scheme}://{domain}:{port}/" : $"{scheme}://{domain}/";
             rootClient = new FaunaClient(secret: faunaSecret, endpoint: faunaEndpoint);
+            rootClientWithCustomHeaders = new FaunaClient(
+                secret: faunaSecret,
+                endpoint: faunaEndpoint,
+                customHeaders: new Dictionary<string, string>
+                {
+                    { "test-header-1", "test-value-1" },
+                    { "test-header-2", "test-value-2" },
+                }
+            );
 
             DbRef = Database(TestDbName);
 
@@ -67,6 +79,7 @@ namespace Test
             adminKey = await rootClient.Query(CreateKey(Obj("database", DbRef, "role", "admin")));
             client = rootClient.NewSessionClient(clientKey.Get(SECRET_FIELD));
             adminClient = rootClient.NewSessionClient(adminKey.Get(SECRET_FIELD));
+            clientWithCustomHeaders = rootClient.NewSessionClient(clientKey.Get(SECRET_FIELD));
         }
 
         [OneTimeTearDown]

--- a/FaunaDB.Client.Test/TestCase.cs
+++ b/FaunaDB.Client.Test/TestCase.cs
@@ -22,10 +22,8 @@ namespace Test
         protected static Field<RefV> REF_FIELD = Field.At("ref").To<RefV>();
 
         protected FaunaClient rootClient;
-        protected FaunaClient rootClientWithCustomHeaders;
         protected Expr DbRef;
         protected FaunaClient client;
-        protected FaunaClient clientWithCustomHeaders;
         protected FaunaClient adminClient;
         protected Value clientKey;
         protected Value adminKey;
@@ -53,15 +51,6 @@ namespace Test
             faunaSecret = env("FAUNA_ROOT_KEY", "secret");
             faunaEndpoint = port != "443" ? $"{scheme}://{domain}:{port}/" : $"{scheme}://{domain}/";
             rootClient = new FaunaClient(secret: faunaSecret, endpoint: faunaEndpoint);
-            rootClientWithCustomHeaders = new FaunaClient(
-                secret: faunaSecret,
-                endpoint: faunaEndpoint,
-                customHeaders: new Dictionary<string, string>
-                {
-                    { "test-header-1", "test-value-1" },
-                    { "test-header-2", "test-value-2" },
-                }
-            );
 
             DbRef = Database(TestDbName);
 
@@ -79,7 +68,6 @@ namespace Test
             adminKey = await rootClient.Query(CreateKey(Obj("database", DbRef, "role", "admin")));
             client = rootClient.NewSessionClient(clientKey.Get(SECRET_FIELD));
             adminClient = rootClient.NewSessionClient(adminKey.Get(SECRET_FIELD));
-            clientWithCustomHeaders = rootClient.NewSessionClient(clientKey.Get(SECRET_FIELD));
         }
 
         [OneTimeTearDown]

--- a/FaunaDB.Client/Client/FaunaClient.cs
+++ b/FaunaDB.Client/Client/FaunaClient.cs
@@ -40,8 +40,9 @@ namespace FaunaDB.Client
             TimeSpan? timeout = null,
             HttpClient httpClient = null,
             Version httpVersion = null,
-            bool checkNewVersion = true)
-            : this(CreateClient(secret, endpoint, timeout, httpClient, httpVersion, checkNewVersion))
+            bool checkNewVersion = true,
+            IReadOnlyDictionary<string, string> customHeaders = null)
+            : this(CreateClient(secret, endpoint, timeout, httpClient, httpVersion, checkNewVersion, customHeaders))
         { }
 
         /// <summary>
@@ -253,7 +254,8 @@ namespace FaunaDB.Client
             TimeSpan? timeout = null,
             HttpClient httpClient = null,
             Version httpVersion = null,
-            bool checkNewVersion = true)
+            bool checkNewVersion = true,
+            IReadOnlyDictionary<string, string> customHeaders = null)
         {
             secret.AssertNotNull(nameof(secret));
             endpoint.AssertNotNull(nameof(endpoint));


### PR DESCRIPTION
### Notes
We need to be able to set the X-Fauna-Source header in some applications that use FaunaClient for user statistics. This PR adds a customHeaders parameter, so users who use it can specify X-Fauna-Source header.

### Jira ticket
https://faunadb.atlassian.net/browse/OSS-846